### PR TITLE
Fix invisible action buttons on mobile

### DIFF
--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -468,7 +468,7 @@
 
 											<!-- Actions -->
 											<div
-												class="flex shrink-0 gap-1 opacity-0 transition-opacity group-hover:opacity-100 sm:opacity-100"
+												class="flex shrink-0 gap-1 transition-opacity sm:opacity-0 sm:group-hover:opacity-100"
 											>
 												<button
 													onclick={() => openEdit(item)}
@@ -583,7 +583,7 @@
 									<!-- Delete -->
 									<button
 										onclick={() => handleDelete(item._id)}
-										class="flex shrink-0 rounded p-1 text-muted-foreground opacity-0 group-hover:opacity-100 hover:bg-destructive/10 hover:text-destructive"
+										class="flex shrink-0 rounded p-1 text-muted-foreground sm:opacity-0 sm:group-hover:opacity-100 hover:bg-destructive/10 hover:text-destructive"
 										aria-label="Delete item"
 									>
 										<svg


### PR DESCRIPTION
## Summary
- Fixes edit/delete buttons being invisible on mobile (< 640px) for active grocery items
- Fixes delete button being invisible on mobile for bought/checked items
- Changes the opacity logic from `opacity-0 group-hover:opacity-100 sm:opacity-100` to `sm:opacity-0 sm:group-hover:opacity-100` — mobile-first visible, hidden-until-hover on desktop only

## Changes
Two class attribute updates in `src/routes/app/+page.svelte`:
1. Active item edit/delete action buttons wrapper div
2. Bought item delete button

## Test plan
- [ ] On mobile (< 640px): edit and delete buttons on active grocery items are visible and tappable
- [ ] On mobile (< 640px): delete button on bought/checked items is visible and tappable
- [ ] On desktop (≥ 640px): edit/delete buttons are hidden by default and appear on row hover
- [ ] No visual regression on desktop — hover behavior unchanged

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)