### PR TITLE
Stack dialog footer buttons vertically and full-width on mobile

### DIFF
--- a/src/lib/components/ui/dialog/dialog-footer.svelte
+++ b/src/lib/components/ui/dialog/dialog-footer.svelte
@@ -18,7 +18,10 @@
 <div
 	bind:this={ref}
 	data-slot="dialog-footer"
-	class={cn('flex flex-col-reverse gap-2 gap-2 sm:flex-row sm:justify-end', className)}
+	class={cn(
+		'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end [&>*]:w-full [&>*]:h-11 sm:[&>*]:w-auto sm:[&>*]:h-9',
+		className
+	)}
 	{...restProps}
 >
 	{@render children?.()}


### PR DESCRIPTION
## Summary

- On mobile viewports (< 640px), dialog footer buttons are now stacked vertically, full-width, and taller (`h-11` / 44px) for comfortable thumb tapping
- Primary action button appears first/on top on mobile (via existing `flex-col-reverse` — primary button is last in HTML)
- On desktop (≥ 640px), the existing horizontal right-aligned layout is preserved
- Single change to `dialog-footer.svelte` applies consistently to all four affected dialogs: Clear bought items, Edit item, Members/invite, and Categories management

## Implementation

The fix is a one-liner in `dialog-footer.svelte` — added two sets of responsive Tailwind utilities:
- `[&>*]:w-full sm:[&>*]:w-auto` — full-width children on mobile, auto-width on desktop
- `[&>*]:h-11 sm:[&>*]:h-9` — 44px height on mobile, default button height on desktop

## Test plan

- [ ] Open any of the four dialogs on a mobile viewport (< 640px) — buttons should be stacked vertically, full-width, and easy to tap
- [ ] Verify primary action button (Save, Clear all) appears **above** Cancel on mobile
- [ ] Open dialogs on desktop (≥ 640px) — buttons should remain in horizontal layout, right-aligned
- [ ] Confirm button height feels comfortable on mobile (≥ 44px)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)